### PR TITLE
Use authorization header from core if it is filled

### DIFF
--- a/resources/js/app.js
+++ b/resources/js/app.js
@@ -21,14 +21,14 @@ Vue.mixin({
                 let headers = {}
 
                 if (this.$root.user) {
-                    headers['Authorization'] = `Bearer ${localStorage.token}`
+                    headers['Authorization'] = window.magentoUser.defaults.headers.common['Authorization']
                 }
 
                 if (window.config.store_code) {
                     headers['Store'] = window.config.store_code
                 }
 
-                let response = await axios({
+                let response = axios({
                     method: method,
                     url: window.url(url),
                     data: variables,


### PR DESCRIPTION
Relevant when the rapidez/core uses a different storage location for the token (not yet)