### PR TITLE
[2.x] Add fallbacks for wishlists not existing

### DIFF
--- a/resources/js/Wishlist.vue
+++ b/resources/js/Wishlist.vue
@@ -40,7 +40,7 @@ export default {
 
     methods: {
         isWishlisted(productId) {
-            return this.wishlists.some(e => this.findItem(e, productId))
+            return this.wishlists && this.wishlists.some(e => this.findItem(e, productId))
         },
 
         findItem(wishlist, productId) {
@@ -61,7 +61,7 @@ export default {
         },
 
         getWishlist(id) {
-            return this.wishlists.find(e => e.id == id);
+            return this.wishlists?.find(e => e.id == id);
         },
 
         addWishlist: create,


### PR DESCRIPTION
When checking if an item is on your wishlist you may end up not (yet) having the wishlists data. This could be because the request is still running, or maybe because something went wrong. Either way, we don't want to unnecessarily throw more errors here.