### PR TITLE
Rapidez v5 fixes

### DIFF
--- a/resources/views/partials/item/title.blade.php
+++ b/resources/views/partials/item/title.blade.php
@@ -4,15 +4,15 @@
     } else {
         update(wishlist.id, wishlist)
     }
-}">
-    <div class="flex items-center" slot-scope="{ toggle, close, isOpen }">
+}" v-slot="{ toggle, close, isOpen }">
+    <div class="flex items-center">
         <template v-if="!isOpen">
             <span class="text truncate peer place-self-start -mt-0.5">
                 @{{ wishlist.title }}
             </span>
             <x-heroicon-s-pencil-square
                 class="pl-2 w-6 h-4 cursor-pointer shrink-0 opacity-0 hover:opacity-100 peer-hover:opacity-50 transition-opacity"
-                v-on:click="toggle"
+                v-on:click.stop="toggle"
             />
         </template>
         <template v-else>

--- a/src/Controllers/WishlistItemController.php
+++ b/src/Controllers/WishlistItemController.php
@@ -5,7 +5,6 @@ namespace Rapidez\MultipleWishlist\Controllers;
 use Illuminate\Foundation\Auth\Access\AuthorizesRequests;
 use Illuminate\Foundation\Bus\DispatchesJobs;
 use Illuminate\Foundation\Validation\ValidatesRequests;
-use Illuminate\Http\JsonResponse;
 use Illuminate\Http\Request;
 use Illuminate\Routing\Controller;
 use Rapidez\MultipleWishlist\Models\RapidezWishlist;
@@ -18,7 +17,7 @@ class WishlistItemController extends Controller
     use DispatchesJobs;
     use ValidatesRequests;
 
-    public function store(Request $request): JsonResponse
+    public function store(Request $request)
     {
         $validated = $request->validate([
             'wishlist_id' => 'required|integer|exclude',


### PR DESCRIPTION
2 small bugs made this package not fully work in 5.x.

It was not possible to add items to your wishlist because of a bad typehint, and the toggler was broken because of slot-scope usage.